### PR TITLE
Upgrade Django to 1.7.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==1.7.4
+Django==1.7.5
 Jinja2==2.7.3
 MarkupSafe==0.23
 PyYAML==3.11


### PR DESCRIPTION
Django released a security release today
(https://docs.djangoproject.com/en/1.7/releases/1.7.5/) to coincide with
their beta release of Django 1.8.
